### PR TITLE
add bash script to build pdf on mac and delete temp files

### DIFF
--- a/src/makepdf_mac.sh
+++ b/src/makepdf_mac.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+ERROR="Too few arguments : no file name specified"
+[[ $# -eq 0 ]] && echo $ERROR && exit # no args? ... print error and exit
+
+if [ -f $1.tex ];then
+    xelatex $1
+    bibtex $1
+    xelatex $1
+    xelatex $1
+    rm *.lof *.lot *.out *.toc *.log *.aux *.bbl *.blg *.bak *.sav *.dvi *.gz
+fi


### PR DESCRIPTION
在安装了最新 MacTex 的 Mac 环境下，进入 src 目录运行 makepdf_mac.sh main 即可生成手册pdf并删除临时文件